### PR TITLE
Terragrunted 2 and 3 Tier examples

### DIFF
--- a/.terragrunt
+++ b/.terragrunt
@@ -1,0 +1,18 @@
+# Configure Terragrunt to use DynamoDB for locking
+lock = {
+  backend = "dynamodb"
+  config {
+  state_file_id = "${path_relative_to_include()}"
+  }
+}
+
+# Configure Terragrunt to automatically store tfstate files in an S3 bucket
+remote_state = {
+  backend = "s3"
+  config {
+    encrypt = "true"
+    bucket = "please-change-my-name"
+    key = "${path_relative_to_include()}/terraform.tfstate"
+    region = "ap-southeast-2"
+  }
+}

--- a/three-tier-rds/.terragrunt
+++ b/three-tier-rds/.terragrunt
@@ -1,0 +1,4 @@
+# Use the parent .terragrunt file passing it the name of this folder
+include = {
+  path = "${find_in_parent_folders()}"
+}

--- a/three-tier-rds/README.md
+++ b/three-tier-rds/README.md
@@ -18,11 +18,17 @@ Set the following variables in variables.tf:
 
 ### Launching
 
-Run these commands:
+Run these commands for **Terraform**:
 
 1. terraform get
 2. terraform plan
 3. terraform apply
+
+... or these if your are using **Terragrunt**
+
+1. terragrunt get
+2. terragrunt plan
+3. terragrunt apply
 
 This command will output your database endpoint, which you will need below.
 

--- a/three-tier-rds/variables.tf
+++ b/three-tier-rds/variables.tf
@@ -3,7 +3,7 @@ variable "region" {
 }
 
 variable "stack_name" {
-  default     = "3tiertest"
+  default     = "threetiertest"
 }
 
 variable "owner" {

--- a/two-tier-vpc/.terragrunt
+++ b/two-tier-vpc/.terragrunt
@@ -1,0 +1,4 @@
+# Use the parent .terragrunt file passing it the name of this folder
+include = {
+  path = "${find_in_parent_folders()}"
+}

--- a/two-tier-vpc/README.md
+++ b/two-tier-vpc/README.md
@@ -14,11 +14,17 @@ Set the following variable in variables.tf:
 
 ### Launching
 
-Run these commands:
+Run these commands for **Terraform**:
 
 1. terraform get
 2. terraform plan
 3. terraform apply
+
+... or these if your are using **Terragrunt**
+
+1. terragrunt get
+2. terragrunt plan
+3. terragrunt apply
 
 This command will output your ELB address, which you will need below.
 

--- a/two-tier-vpc/variables.tf
+++ b/two-tier-vpc/variables.tf
@@ -3,7 +3,7 @@ variable "region" {
 }
 
 variable "stack_name" {
-  default = "2tiertest"
+  default = "twotiertest"
 }
 
 variable "owner" {


### PR DESCRIPTION
Added   .terragrunt,   **three-tier-rds**/.terragrunt,   **two-tier-vpc**/.terragrunt   to Terraform examples

Modified   **three-tier-rds**/README.md and **two-tier-vpc**/README.md   to included instructions for Terragrunt

Modified   **three-tier-rds**/variables.tf and **two-tier-vpc**/variables.tf   to remove digits from the stack name as it caused issues with Terragrunt
